### PR TITLE
Scrum-101 conectar el aplicativo con mercados europeos sudamericanos y asiaticos

### DIFF
--- a/AccionesUD_Backend/pom.xml
+++ b/AccionesUD_Backend/pom.xml
@@ -108,6 +108,13 @@
 			</dependency>
 
 			<dependency>
+    <groupId>org.json</groupId>
+    <artifactId>json</artifactId>
+    <version>20230227</version>
+</dependency>
+
+
+			<dependency>
     <groupId>org.mockito</groupId>
     <artifactId>mockito-core</artifactId>
     <version>5.2.0</version>

--- a/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/application/AlphaVantage/AlphaVantageStockService.java
+++ b/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/application/AlphaVantage/AlphaVantageStockService.java
@@ -1,0 +1,72 @@
+package com.AccionesUD.AccionesUD.application.AlphaVantage;
+
+import com.AccionesUD.AccionesUD.dto.AlphaVantage.StockDTO;
+import com.AccionesUD.AccionesUD.repository.AlphaVantage.StockApiClient;
+import com.AccionesUD.AccionesUD.utilities.CachedStockData;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class AlphaVantageStockService implements StockService {
+
+    private final StockApiClient stockApiClient;
+    private final Map<String, CachedStockData> cache = new ConcurrentHashMap<>();
+    private final long ttlMillis = 60_000; // 1 minuto
+
+    public AlphaVantageStockService(StockApiClient stockApiClient) {
+        this.stockApiClient = stockApiClient;
+    }
+
+    @Override
+    public StockDTO getStockInfo(String symbol) {
+        // Revisa si está en caché
+        CachedStockData cached = cache.get(symbol);
+        if (cached != null && !cached.isExpired()) {
+            System.out.println("[CACHE HIT] Usando datos en caché para: " + symbol);
+            return cached.getData();
+        }
+
+        System.out.println("[CACHE MISS] Llamando a la API externa de Alpha Vantage para: " + symbol);
+
+        // Si no está o está expirado, consulta la API y guarda
+        var overview = stockApiClient.fetchOverview(symbol);
+        var prices = stockApiClient.fetchDailyPrice(symbol);
+
+        if (!prices.has("Time Series (Daily)")) {
+            String errorMsg = prices.has("Note") ? prices.getString("Note") :
+                              prices.has("Information") ? prices.getString("Information") :
+                              prices.has("Error Message") ? prices.getString("Error Message") :
+                              "Respuesta inesperada.";
+            System.out.println("[API ERROR] Alpha Vantage respuesta inválida: " + prices.toString(2));
+            throw new RuntimeException("Error al obtener precios para el símbolo '" + symbol + "': " + errorMsg);
+        }
+
+        var series = prices.getJSONObject("Time Series (Daily)");
+        String mostRecentKey = series.keySet().stream()
+            .sorted(Comparator.reverseOrder())
+            .findFirst()
+            .orElseThrow(() -> new RuntimeException("No hay datos disponibles"));
+
+        var lastData = series.getJSONObject(mostRecentKey);
+        Double price = Double.parseDouble(lastData.getString("4. close"));
+        Long volume = Long.parseLong(lastData.getString("5. volume"));
+
+        String name = overview.optString("Name", "N/A");
+        String sector = overview.optString("Sector", "N/A");
+        Long marketCap = overview.has("MarketCapitalization")
+                         ? Long.parseLong(overview.getString("MarketCapitalization"))
+                         : null;
+
+        StockDTO dto = new StockDTO(symbol, name, sector, price, volume, marketCap);
+
+        // Guardar en caché
+        cache.put(symbol, new CachedStockData(dto, ttlMillis));
+        System.out.println("[CACHE STORE] Datos guardados en caché para: " + symbol);
+
+        return dto;
+    }
+}

--- a/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/application/AlphaVantage/StockService.java
+++ b/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/application/AlphaVantage/StockService.java
@@ -1,0 +1,7 @@
+package com.AccionesUD.AccionesUD.application.AlphaVantage;
+
+import com.AccionesUD.AccionesUD.dto.AlphaVantage.StockDTO;
+
+public interface StockService {
+    StockDTO getStockInfo(String symbol);
+}

--- a/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/application/TwelveData/TwelveDataStockService.java
+++ b/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/application/TwelveData/TwelveDataStockService.java
@@ -3,48 +3,48 @@ package com.AccionesUD.AccionesUD.application.TwelveData;
 import com.AccionesUD.AccionesUD.dto.AlphaVantage.StockDTO;
 import com.AccionesUD.AccionesUD.repository.TwelveData.TwelveDataApiClient;
 import com.AccionesUD.AccionesUD.utilities.CachedStockData;
+import org.json.JSONObject;
+import org.springframework.stereotype.Service;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-
-import org.json.JSONObject;
-import org.springframework.stereotype.Service;
 
 @Service
 public class TwelveDataStockService {
 
     private final TwelveDataApiClient apiClient;
     private final Map<String, CachedStockData> cache = new ConcurrentHashMap<>();
-    private final long ttlMillis = 60_000;
+    private final long ttlMillis = 60_000; // 1 minuto
 
     public TwelveDataStockService(TwelveDataApiClient apiClient) {
         this.apiClient = apiClient;
     }
 
     public StockDTO getStockInfo(String symbol) {
+        // Revisa el caché primero
         CachedStockData cached = cache.get(symbol);
         if (cached != null && !cached.isExpired()) {
-            System.out.println("[CACHE HIT] TwelveData para: " + symbol);
+            System.out.println("[CACHE HIT] TwelveData: " + symbol);
             return cached.getData();
         }
 
-        System.out.println("[CACHE MISS] TwelveData API para: " + symbol);
+        System.out.println("[CACHE MISS] TwelveData: " + symbol);
         JSONObject quote = apiClient.fetchQuote(symbol);
 
         if (quote.has("code")) {
-            throw new RuntimeException("Error: " + quote.optString("message"));
+            throw new RuntimeException("Error al obtener cotización: " + quote.optString("message"));
         }
 
-        String ticker = quote.optString("symbol", symbol);
         String name = quote.optString("name", "N/A");
+        String ticker = quote.optString("symbol", symbol);
         String exchange = quote.optString("exchange", "N/A");
         Double price = quote.has("close") ? Double.parseDouble(quote.getString("close")) : null;
         Long volume = quote.has("volume") ? Long.parseLong(quote.getString("volume")) : null;
 
         StockDTO dto = new StockDTO(ticker, name, exchange, price, volume, null);
 
+        // Guarda en caché
         cache.put(symbol, new CachedStockData(dto, ttlMillis));
-        System.out.println("[CACHE STORE] TwelveData: " + symbol);
         return dto;
     }
 }

--- a/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/application/TwelveData/TwelveDataStockService.java
+++ b/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/application/TwelveData/TwelveDataStockService.java
@@ -1,0 +1,50 @@
+package com.AccionesUD.AccionesUD.application.TwelveData;
+
+import com.AccionesUD.AccionesUD.dto.AlphaVantage.StockDTO;
+import com.AccionesUD.AccionesUD.repository.TwelveData.TwelveDataApiClient;
+import com.AccionesUD.AccionesUD.utilities.CachedStockData;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.json.JSONObject;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TwelveDataStockService {
+
+    private final TwelveDataApiClient apiClient;
+    private final Map<String, CachedStockData> cache = new ConcurrentHashMap<>();
+    private final long ttlMillis = 60_000;
+
+    public TwelveDataStockService(TwelveDataApiClient apiClient) {
+        this.apiClient = apiClient;
+    }
+
+    public StockDTO getStockInfo(String symbol) {
+        CachedStockData cached = cache.get(symbol);
+        if (cached != null && !cached.isExpired()) {
+            System.out.println("[CACHE HIT] TwelveData para: " + symbol);
+            return cached.getData();
+        }
+
+        System.out.println("[CACHE MISS] TwelveData API para: " + symbol);
+        JSONObject quote = apiClient.fetchQuote(symbol);
+
+        if (quote.has("code")) {
+            throw new RuntimeException("Error: " + quote.optString("message"));
+        }
+
+        String ticker = quote.optString("symbol", symbol);
+        String name = quote.optString("name", "N/A");
+        String exchange = quote.optString("exchange", "N/A");
+        Double price = quote.has("close") ? Double.parseDouble(quote.getString("close")) : null;
+        Long volume = quote.has("volume") ? Long.parseLong(quote.getString("volume")) : null;
+
+        StockDTO dto = new StockDTO(ticker, name, exchange, price, volume, null);
+
+        cache.put(symbol, new CachedStockData(dto, ttlMillis));
+        System.out.println("[CACHE STORE] TwelveData: " + symbol);
+        return dto;
+    }
+}

--- a/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/controller/AlphaVantage/StockControllerAlpha.java
+++ b/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/controller/AlphaVantage/StockControllerAlpha.java
@@ -1,0 +1,24 @@
+package com.AccionesUD.AccionesUD.controller.AlphaVantage;
+
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.AccionesUD.AccionesUD.application.AlphaVantage.StockService;
+import com.AccionesUD.AccionesUD.dto.AlphaVantage.StockDTO;
+
+
+@RestController
+@RequestMapping("/api/stocks/alpha") // cambia el prefijo
+public class StockControllerAlpha {
+
+    private final StockService stockService;
+
+    public StockControllerAlpha(StockService stockService) {
+        this.stockService = stockService;
+    }
+
+    @GetMapping("/{symbol}")
+    public ResponseEntity<StockDTO> getStock(@PathVariable String symbol) {
+        return ResponseEntity.ok(stockService.getStockInfo(symbol));
+    }
+}

--- a/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/controller/AlphaVantage/SymbolSearchController.java
+++ b/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/controller/AlphaVantage/SymbolSearchController.java
@@ -1,0 +1,28 @@
+package com.AccionesUD.AccionesUD.controller.AlphaVantage;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.http.ResponseEntity;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import com.AccionesUD.AccionesUD.repository.AlphaVantage.StockApiClient;
+
+@RestController
+@RequestMapping("/api/stocks/search")
+@RequiredArgsConstructor
+public class SymbolSearchController {
+
+    private final StockApiClient stockApiClient;
+
+    @GetMapping("/{keyword}")
+    public ResponseEntity<?> searchSymbol(@PathVariable String keyword) {
+        try {
+            JSONObject response = stockApiClient.searchSymbol(keyword);
+            JSONArray matches = response.optJSONArray("bestMatches");
+            return ResponseEntity.ok(matches != null ? matches.toList() : "No matches found.");
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body("Error al buscar símbolo: " + e.getMessage());
+        }
+    }
+}

--- a/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/controller/TwelveData/MarketListTwelveController.java
+++ b/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/controller/TwelveData/MarketListTwelveController.java
@@ -1,0 +1,49 @@
+package com.AccionesUD.AccionesUD.controller.TwelveData;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.AccionesUD.AccionesUD.repository.TwelveData.TwelveDataApiClient;
+
+import java.util.Set;
+import java.util.TreeSet;
+
+@RestController
+@RequestMapping("/api/stocks/twelve/markets")
+public class MarketListTwelveController {
+
+    private final TwelveDataApiClient apiClient;
+
+    public MarketListTwelveController(TwelveDataApiClient apiClient) {
+        this.apiClient = apiClient;
+    }
+
+    @GetMapping
+    public ResponseEntity<?> getMarkets(@RequestParam(defaultValue = "toyota") String keyword) {
+        try {
+            JSONObject response = apiClient.searchSymbol(keyword);
+            JSONArray data = response.optJSONArray("data");
+
+            Set<String> countries = new TreeSet<>();
+            Set<String> micCodes = new TreeSet<>();
+
+            if (data != null) {
+                for (int i = 0; i < data.length(); i++) {
+                    JSONObject item = data.getJSONObject(i);
+                    countries.add(item.optString("country", "Unknown"));
+                    micCodes.add(item.optString("mic_code", "Unknown"));
+                }
+            }
+
+            JSONObject result = new JSONObject();
+            result.put("countries", countries);
+            result.put("mic_codes", micCodes);
+
+            return ResponseEntity.ok(result.toString(2));
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body("Error al obtener mercados: " + e.getMessage());
+        }
+    }
+}

--- a/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/controller/TwelveData/StockControllerTwelveData.java
+++ b/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/controller/TwelveData/StockControllerTwelveData.java
@@ -1,0 +1,22 @@
+package com.AccionesUD.AccionesUD.controller.TwelveData;
+
+import com.AccionesUD.AccionesUD.application.TwelveData.TwelveDataStockService;
+import com.AccionesUD.AccionesUD.dto.AlphaVantage.StockDTO;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/stocks/twelve")
+public class StockControllerTwelveData {
+
+    private final TwelveDataStockService stockService;
+
+    public StockControllerTwelveData(TwelveDataStockService stockService) {
+        this.stockService = stockService;
+    }
+
+    @GetMapping("/{symbol}")
+    public ResponseEntity<StockDTO> getStock(@PathVariable String symbol) {
+        return ResponseEntity.ok(stockService.getStockInfo(symbol));
+    }
+}

--- a/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/controller/TwelveData/SymbolSearchTwelveController.java
+++ b/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/controller/TwelveData/SymbolSearchTwelveController.java
@@ -1,0 +1,48 @@
+package com.AccionesUD.AccionesUD.controller.TwelveData;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.AccionesUD.AccionesUD.repository.TwelveData.TwelveDataApiClient;
+
+@RestController
+@RequestMapping("/api/stocks/twelve/search")
+public class SymbolSearchTwelveController {
+
+    private final TwelveDataApiClient apiClient;
+
+    public SymbolSearchTwelveController(TwelveDataApiClient apiClient) {
+        this.apiClient = apiClient;
+    }
+
+    @GetMapping("/{keyword}")
+    public ResponseEntity<?> search(@PathVariable String keyword, @RequestParam(required = false) String country, @RequestParam(required = false) String mic) {
+        try {
+            JSONObject response = apiClient.searchSymbol(keyword);
+            JSONArray data = response.optJSONArray("data");
+            JSONArray filtradas = new JSONArray();
+
+            if (data != null) {
+                for (int i = 0; i < data.length(); i++) {
+                    JSONObject item = data.getJSONObject(i);
+                    boolean matchCountry = (country == null || country.equalsIgnoreCase(item.optString("country")));
+                    boolean matchMic = (mic == null || mic.equalsIgnoreCase(item.optString("mic_code")));
+                    if (matchCountry && matchMic) {
+                        filtradas.put(item);
+                    }
+                }
+            }
+
+            return ResponseEntity.ok(filtradas.toString(2));
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body("Error: " + e.getMessage());
+        }
+    }
+
+}

--- a/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/domain/model/AlphaVantage/Stock.java
+++ b/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/domain/model/AlphaVantage/Stock.java
@@ -1,0 +1,26 @@
+package com.AccionesUD.AccionesUD.domain.model.AlphaVantage;
+
+import lombok.Data;
+
+@Data
+public class Stock {
+    private String ticker;
+    private String companyName;
+    private String sector;
+    private Double price;
+    private Long volume;
+    private Long marketCap;
+
+    // Constructors, getters, setters
+    public Stock() {}
+
+    public Stock(String ticker, String companyName, String sector, Double price, Long volume, Long marketCap) {
+        this.ticker = ticker;
+        this.companyName = companyName;
+        this.sector = sector;
+        this.price = price;
+        this.volume = volume;
+        this.marketCap = marketCap;
+    }
+
+}

--- a/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/dto/AlphaVantage/StockDTO.java
+++ b/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/dto/AlphaVantage/StockDTO.java
@@ -1,0 +1,24 @@
+package com.AccionesUD.AccionesUD.dto.AlphaVantage;
+
+import lombok.Data;
+
+@Data
+public class StockDTO {
+    public String ticker;
+    public String companyName;
+    public String sector;
+    public Double price;
+    public Long volume;
+    public Long marketCap;
+
+    public StockDTO(String ticker, String companyName, String sector, Double price, Long volume, Long marketCap) {
+        this.ticker = ticker;
+        this.companyName = companyName;
+        this.sector = sector;
+        this.price = price;
+        this.volume = volume;
+        this.marketCap = marketCap;
+    }
+
+    // Getters y setters si necesitas
+}

--- a/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/repository/AlphaVantage/StockApiClient.java
+++ b/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/repository/AlphaVantage/StockApiClient.java
@@ -1,0 +1,40 @@
+package com.AccionesUD.AccionesUD.repository.AlphaVantage;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.client.RestTemplate;
+import org.json.JSONObject;
+
+
+import java.util.Iterator;
+
+@Repository
+public class StockApiClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${alphavantage.api.key}")
+    private String apiKey;
+
+    public StockApiClient(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    public JSONObject fetchOverview(String symbol) {
+        String url = "https://www.alphavantage.co/query?function=OVERVIEW&symbol=" + symbol + "&apikey=" + apiKey;
+        String response = restTemplate.getForObject(url, String.class);
+        return new JSONObject(response);
+    }
+public JSONObject fetchDailyPrice(String symbol) {
+    String url = "https://www.alphavantage.co/query?function=TIME_SERIES_DAILY&symbol=" + symbol + "&apikey=" + apiKey;
+    String response = restTemplate.getForObject(url, String.class);
+    return new JSONObject(response);
+}
+
+public JSONObject searchSymbol(String keyword) {
+    String url = "https://www.alphavantage.co/query?function=SYMBOL_SEARCH&keywords=" + keyword + "&apikey=" + apiKey;
+    String response = restTemplate.getForObject(url, String.class);
+    return new JSONObject(response);
+}
+
+}

--- a/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/repository/TwelveData/TwelveDataApiClient.java
+++ b/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/repository/TwelveData/TwelveDataApiClient.java
@@ -1,0 +1,31 @@
+package com.AccionesUD.AccionesUD.repository.TwelveData;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.client.RestTemplate;
+import org.json.JSONObject;
+
+@Repository
+public class TwelveDataApiClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${twelvedata.api.key}")
+    private String apiKey;
+
+    public TwelveDataApiClient(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    public JSONObject fetchQuote(String symbol) {
+        String url = "https://api.twelvedata.com/quote?symbol=" + symbol + "&apikey=" + apiKey;
+        String response = restTemplate.getForObject(url, String.class);
+        return new JSONObject(response);
+    }
+
+    public JSONObject searchSymbol(String keyword) {
+        String url = "https://api.twelvedata.com/symbol_search?symbol=" + keyword + "&apikey=" + apiKey;
+        String response = restTemplate.getForObject(url, String.class);
+        return new JSONObject(response);
+    }
+}

--- a/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/utilities/CachedStockData.java
+++ b/AccionesUD_Backend/src/main/java/com/AccionesUD/AccionesUD/utilities/CachedStockData.java
@@ -1,0 +1,21 @@
+package com.AccionesUD.AccionesUD.utilities;
+
+import com.AccionesUD.AccionesUD.dto.AlphaVantage.StockDTO;
+
+public class CachedStockData {
+    private final StockDTO data;
+    private final long expirationTimeMillis;
+
+    public CachedStockData(StockDTO data, long ttlMillis) {
+        this.data = data;
+        this.expirationTimeMillis = System.currentTimeMillis() + ttlMillis;
+    }
+
+    public boolean isExpired() {
+        return System.currentTimeMillis() > expirationTimeMillis;
+    }
+
+    public StockDTO getData() {
+        return data;
+    }
+}

--- a/AccionesUD_Backend/src/main/resources/application.properties
+++ b/AccionesUD_Backend/src/main/resources/application.properties
@@ -22,3 +22,6 @@ spring.mail.properties.mail.smtp.localhost=localhost
 
 alpaca.api.key=PKK5NQYWLLIU97UMTLEW
 alpaca.api.secret=Wd7rfqUdxUZdf8nFVQmLIBeKcLOSbdjigM8b1cuq
+
+alphavantage.api.key=OUP9KO59IV8NPP6G
+twelvedata.api.key=c3da062da3274361b8f3454b3df2a72f


### PR DESCRIPTION
Se implementó exitosamente la integración con la API de Twelve Data para consultar información de acciones listadas en distintos mercados bursátiles internacionales, incluyendo algunos mercados de Europa, Asia y Sudamérica. Esta funcionalidad permite a la plataforma obtener cotizaciones, nombres de empresas, volumen negociado, moneda, país y bolsa en la que cotiza cada acción.

Dado que Twelve Data impone un límite de 800 solicitudes diarias en su plan gratuito, se desarrolló un mecanismo de caché con tiempo de vida de un minuto, que almacena temporalmente los datos solicitados por símbolo. Esto permite reducir significativamente el número de llamadas a la API sin afectar la precisión de los resultados.

Esta implementación establece la base para consultar de forma centralizada y eficiente los distintos mercados internacionales, cumpliendo con los requerimientos del proyecto en cuanto a diversidad de instrumentos financieros y representación de regiones fuera de Estados Unidos.